### PR TITLE
.lua files should go into texmf/scripts ?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ name := lualatex-math
 texmf := $(shell kpsewhich --var-value=TEXMFHOME)
 branch := lualatex/$(name)
 destdir := $(texmf)/tex/$(branch)
+scriptdir := $(texmf)/scripts/$(name)
 docdir := $(texmf)/doc/$(branch)
 auctexdir := ~/.emacs.d/auctex/style
 
@@ -71,7 +72,9 @@ ctan: $(ctan_arch)
 
 install: all
 	$(INSTALL) -d $(destdir)
-	$(INSTALL_DATA) $(destination) $(destdir)
+	$(INSTALL) -d $(scriptdir)
+	$(INSTALL_DATA) $(dest_sty) $(destdir)
+	$(INSTALL_DATA) $(dest_lua) $(scriptdir)
 	$(INSTALL) -d $(auctexdir)
 	$(INSTALL_DATA) $(auctex_style) $(auctexdir)
 	$(MKTEXLSR)


### PR DESCRIPTION
Unless I'm mistaken (still on TL2010; just about to update), the .lua file should be installed into $(texmfhome)/scripts/lualatex-math :

```
$ kpsewhich lualatex-math.lua
/usr/local/texlive/2010/texmf-dist/scripts/lualatex-math/lualatex-math.lua
```
